### PR TITLE
feat: add multi-choice prediction support + auto .env loading

### DIFF
--- a/_deprecated_murmur/fetcher.py
+++ b/_deprecated_murmur/fetcher.py
@@ -7,7 +7,7 @@ from urllib.parse import urlparse
 
 import httpx
 
-from .models import Event, OrderBook, OrderBookLevel, OutcomeToken, PricePoint
+from .models import Event, Market, OrderBook, OrderBookLevel, OutcomeToken, PricePoint
 
 # API endpoints
 CLOB_API_BASE = "https://clob.polymarket.com"
@@ -131,9 +131,29 @@ class PolymarketFetcher:
                 return default or []
         return value if value else (default or [])
 
+    @staticmethod
+    def _extract_outcome_label(question: str, event_title: str) -> str:
+        """Extract the outcome label from a market question.
+        E.g., 'Will Michigan win the 2026 NCAA Tournament?' → 'Michigan'
+        """
+        q = question.strip().rstrip("?")
+        # Try "Will X win/hit/be/reach..." pattern
+        match = re.match(r'^Will\s+(.+?)\s+(?:win|hit|be|reach|beat|finish|pass|enter|visit)', q, re.IGNORECASE)
+        if match:
+            return match.group(1).strip()
+        # Try "Will X ..." generic
+        match = re.match(r'^Will\s+(.+?)\s+', q, re.IGNORECASE)
+        if match:
+            label = match.group(1).strip()
+            if len(label) < 60:
+                return label
+        # Fallback: use the question minus the event title
+        return q[:60]
+
     def _parse_event(self, data: dict) -> Event:
         """Parse event data from Gamma API response."""
         tokens = []
+        parsed_markets = []
         markets = data.get("markets", [])
 
         for market in markets:
@@ -141,6 +161,26 @@ class PolymarketFetcher:
             outcomes = self._parse_json_field(market.get("outcomes"), ["Yes", "No"])
             prices = self._parse_json_field(market.get("outcomePrices"), ["0.5", "0.5"])
             token_ids = self._parse_json_field(market.get("clobTokenIds"), ["", ""])
+
+            # Find YES price and token_id
+            yes_price = 0.5
+            yes_token_id = ""
+            for i, outcome in enumerate(outcomes):
+                if outcome.lower() in ("yes", "true", "1"):
+                    yes_price = float(prices[i]) if i < len(prices) else 0.5
+                    yes_token_id = token_ids[i] if i < len(token_ids) else ""
+                    break
+
+            question = market.get("question", "")
+            # Prefer groupItemTitle for cleaner labels (e.g. "↑ $120", "Arizona")
+            label = market.get("groupItemTitle") or self._extract_outcome_label(question, data.get("title", ""))
+            parsed_markets.append(Market(
+                question=question,
+                outcome_label=label,
+                yes_price=yes_price,
+                token_id=yes_token_id or market.get("conditionId", ""),
+                closed=market.get("closed", False),
+            ))
 
             for i, outcome in enumerate(outcomes):
                 token_id = token_ids[i] if i < len(token_ids) else ""
@@ -195,6 +235,7 @@ class PolymarketFetcher:
             outcome=outcome,
             outcome_price=outcome_price,
             tokens=tokens,
+            markets=parsed_markets,
             volume=float(data.get("volume", 0) or 0),
             liquidity=float(data.get("liquidity", 0) or 0),
         )

--- a/_deprecated_murmur/models.py
+++ b/_deprecated_murmur/models.py
@@ -46,6 +46,15 @@ class OutcomeToken(BaseModel):
     price: float = Field(ge=0, le=1)
 
 
+class Market(BaseModel):
+    """A single market within a multi-outcome event."""
+    question: str
+    outcome_label: str  # Extracted label (e.g. team name, rate level)
+    yes_price: float = Field(ge=0, le=1)
+    token_id: str = ""
+    closed: bool = False
+
+
 class Event(BaseModel):
     """A Polymarket event with its markets."""
     id: str
@@ -59,8 +68,14 @@ class Event(BaseModel):
     outcome: Optional[str] = None  # For resolved events
     outcome_price: Optional[float] = None  # Final price (0 or 1 for resolved)
     tokens: list[OutcomeToken] = Field(default_factory=list)
+    markets: list[Market] = Field(default_factory=list)  # Per-market data for multi-outcome events
     volume: float = 0.0
     liquidity: float = 0.0
+
+    @property
+    def is_multi_outcome(self) -> bool:
+        """True if this event has multiple markets (multi-choice)."""
+        return len(self.markets) > 1
 
 
 class NewsSignal(BaseModel):

--- a/_deprecated_murmur/strategy.py
+++ b/_deprecated_murmur/strategy.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from groq import Groq
 
-from .models import Event, NewsSignal, OrderBook, PricePoint, Prediction
+from .models import Event, Market, NewsSignal, OrderBook, PricePoint, Prediction
 
 
 class PredictionStrategy(ABC):
@@ -101,6 +101,159 @@ class LLMStrategy(PredictionStrategy):
                 trajectory_7d=[market_prob] * 7,
                 market_price=market_prob,
             )
+
+    def predict_multi(
+        self,
+        event: Event,
+        news_signals: list[NewsSignal],
+    ) -> list[dict]:
+        """Predict probabilities for all outcomes in a multi-choice event.
+        Returns a list of dicts with outcome_label, market_price, predicted_prob, reasoning.
+        """
+        if not self.groq_api_key:
+            raise ValueError("GROQ_API_KEY not set")
+
+        # Filter to active (non-closed) markets with meaningful prices
+        # Exclude placeholder markets (e.g. "Team 48") and eliminated (0%) outcomes
+        active_markets = [
+            m for m in event.markets
+            if not m.closed
+            and m.yes_price > 0.001
+            and not re.match(r'^Team \d+$', m.outcome_label)
+        ]
+        if not active_markets:
+            active_markets = [m for m in event.markets if not m.closed and m.yes_price > 0.001]
+
+        # Build the outcomes table for the LLM
+        outcomes_text = "\n".join(
+            f"  - {m.outcome_label}: market price = {m.yes_price:.1%}"
+            for m in active_markets
+        )
+
+        # News context
+        news_text = "None"
+        if news_signals:
+            sorted_signals = sorted(news_signals, key=lambda x: x.relevance, reverse=True)[:10]
+            news_items = []
+            for s in sorted_signals:
+                news_items.append(f"  - [{s.sentiment or 'neutral'}] {s.title} ({s.source})")
+            news_text = "\n".join(news_items)
+
+        prompt = f"""Analyze this multi-outcome prediction market and predict probabilities for each outcome.
+
+EVENT: {event.title}
+DESCRIPTION: {(event.description or '')[:500]}
+END DATE: {event.end_date.isoformat() if event.end_date else 'Unknown'}
+VOLUME: ${event.volume:,.0f} | LIQUIDITY: ${event.liquidity:,.0f}
+
+OUTCOMES AND CURRENT MARKET PRICES:
+{outcomes_text}
+
+NEWS SIGNALS:
+{news_text}
+
+For each outcome, predict your probability (0-1). Your probabilities should sum to approximately 1.0.
+Focus on finding alpha — where the market might be over- or under-pricing an outcome.
+
+Respond in this exact JSON format:
+{{
+    "predictions": [
+        {{"outcome": "<label>", "probability": <float 0-1>, "reasoning": "<brief reasoning>"}},
+        ...
+    ],
+    "overall_analysis": "<1-2 sentence summary>"
+}}
+
+Include ALL outcomes listed above. Output valid JSON only."""
+
+        try:
+            client = Groq(api_key=self.groq_api_key)
+            response = client.chat.completions.create(
+                model=self.model,
+                messages=[
+                    {"role": "system", "content": "You are an expert prediction market analyst. Analyze multi-outcome events and predict calibrated probabilities. Your probabilities across all outcomes should sum to approximately 1.0."},
+                    {"role": "user", "content": prompt},
+                ],
+                temperature=0.2,
+                max_tokens=4000,
+            )
+
+            content = response.choices[0].message.content.strip()
+            data = None
+
+            # Parse JSON
+            code_match = re.search(r'```json\s*(\{[\s\S]*?\})\s*```', content)
+            if code_match:
+                try:
+                    data = json.loads(code_match.group(1))
+                except json.JSONDecodeError:
+                    pass
+
+            if data is None:
+                start = content.find('{')
+                if start >= 0:
+                    depth = 0
+                    for i, ch in enumerate(content[start:], start):
+                        if ch == '{':
+                            depth += 1
+                        elif ch == '}':
+                            depth -= 1
+                            if depth == 0:
+                                try:
+                                    data = json.loads(content[start:i+1])
+                                except json.JSONDecodeError:
+                                    pass
+                                break
+
+            if not data or "predictions" not in data:
+                # Fallback: return market prices as predictions
+                return [
+                    {"outcome": m.outcome_label, "market_price": m.yes_price,
+                     "predicted_prob": m.yes_price, "reasoning": "Could not parse LLM response"}
+                    for m in active_markets
+                ]
+
+            # Match LLM predictions to markets
+            llm_preds = {p["outcome"].lower(): p for p in data["predictions"]}
+            results = []
+            for m in active_markets:
+                label_lower = m.outcome_label.lower()
+                # Try exact match, then substring match
+                pred = llm_preds.get(label_lower)
+                if not pred:
+                    for k, v in llm_preds.items():
+                        if k in label_lower or label_lower in k:
+                            pred = v
+                            break
+
+                raw_prob = float(pred["probability"]) if pred else m.yes_price
+                reasoning = pred.get("reasoning", "") if pred else ""
+
+                # Apply calibration blend
+                cal_market = self._calibration_correct(m.yes_price)
+                llm_weight = 0.4
+                blended = cal_market * (1 - llm_weight) + raw_prob * llm_weight
+                blended = max(0.01, min(0.99, blended))
+
+                results.append({
+                    "outcome": m.outcome_label,
+                    "market_price": m.yes_price,
+                    "predicted_prob": blended,
+                    "raw_llm_prob": raw_prob,
+                    "reasoning": reasoning,
+                })
+
+            # Sort by predicted probability descending
+            results.sort(key=lambda x: x["predicted_prob"], reverse=True)
+            return results
+
+        except Exception as e:
+            print(f"Error in multi-choice prediction: {e}")
+            return [
+                {"outcome": m.outcome_label, "market_price": m.yes_price,
+                 "predicted_prob": m.yes_price, "reasoning": f"Error: {str(e)}"}
+                for m in active_markets
+            ]
 
     @staticmethod
     def _calibration_correct(p: float) -> float:

--- a/predict.py
+++ b/predict.py
@@ -4,6 +4,9 @@
 import argparse
 import asyncio
 import sys
+
+from dotenv import load_dotenv
+load_dotenv()
 from typing import Optional
 
 from rich.console import Console
@@ -57,7 +60,24 @@ async def predict_event(url_or_slug: str, use_evolved: bool = False) -> None:
             ))
 
             # Show current market prices
-            if event.tokens:
+            import re as _re
+            if event.is_multi_outcome:
+                # Compact display for multi-outcome events
+                active_markets = [
+                    m for m in event.markets
+                    if not m.closed and m.yes_price > 0.001
+                    and not _re.match(r'^Team \d+$', m.outcome_label)
+                ]
+                if active_markets:
+                    table = Table(title=f"Current Market Prices ({len(active_markets)} active outcomes)")
+                    table.add_column("Outcome", style="cyan", max_width=30)
+                    table.add_column("Market Price", justify="right", style="green")
+                    for m in sorted(active_markets, key=lambda x: x.yes_price, reverse=True)[:20]:
+                        table.add_row(m.outcome_label, f"{m.yes_price:.1%}")
+                    if len(active_markets) > 20:
+                        table.add_row(f"... +{len(active_markets) - 20} more", "")
+                    console.print(table)
+            elif event.tokens:
                 table = Table(title="Current Market Prices")
                 table.add_column("Outcome", style="cyan")
                 table.add_column("Price", justify="right", style="green")
@@ -103,40 +123,100 @@ async def predict_event(url_or_slug: str, use_evolved: bool = False) -> None:
             else:
                 strategy = get_default_strategy()
 
-            # Run prediction
-            prediction = strategy.predict(event, price_history, news_signals, orderbook)
+            # Detect multi-outcome event
+            is_multi = event.is_multi_outcome
+
+            if is_multi:
+                progress.update(task, description="Running multi-choice prediction...")
+                multi_results = strategy.predict_multi(event, news_signals)
+            else:
+                # Run single prediction
+                prediction = strategy.predict(event, price_history, news_signals, orderbook)
 
         # Display prediction results
         console.print()
 
-        # Prediction panel
-        prob_color = "green" if prediction.probability > 0.5 else "red"
-        market_diff = prediction.probability - (event.tokens[0].price if event.tokens else 0.5)
-        diff_sign = "+" if market_diff > 0 else ""
+        if is_multi:
+            # --- Multi-choice display ---
+            active_results = [
+                r for r in multi_results
+                if r["market_price"] > 0.001
+                and not _re.match(r'^Team \d+$', r["outcome"])
+            ]
+            if not active_results:
+                active_results = multi_results
 
-        console.print(Panel(
-            f"[bold {prob_color}]{prediction.probability:.1%}[/bold {prob_color}] probability of YES\n\n"
-            f"Confidence: [bold]{prediction.confidence:.1%}[/bold]\n"
-            f"Market price: {event.tokens[0].price:.1%}\n"
-            f"Difference: [{'green' if market_diff > 0 else 'red'}]{diff_sign}{market_diff:.1%}[/]",
-            title="Prediction",
-            border_style="green" if prediction.probability > 0.5 else "red",
-        ))
+            console.print(Panel(
+                f"[bold]Multi-outcome event with {len(active_results)} active choices[/bold]",
+                title="Multi-Choice Prediction",
+                border_style="blue",
+            ))
 
-        # Reasoning
-        console.print(Panel(
-            prediction.reasoning,
-            title="Reasoning",
-            border_style="yellow",
-        ))
+            table = Table(title="Ranked Predictions")
+            table.add_column("#", style="dim", width=4)
+            table.add_column("Outcome", style="cyan", max_width=30)
+            table.add_column("Market", justify="right", style="yellow")
+            table.add_column("Predicted", justify="right", style="bold green")
+            table.add_column("Edge", justify="right")
+            table.add_column("Reasoning", max_width=45)
 
-        # 7-day trajectory
-        if prediction.trajectory_7d:
-            table = Table(title="7-Day Price Trajectory")
-            for i, price in enumerate(prediction.trajectory_7d, 1):
-                table.add_column(f"Day {i}", justify="center")
-            table.add_row(*[f"{p:.1%}" for p in prediction.trajectory_7d])
+            for i, r in enumerate(active_results[:20], 1):
+                edge = r["predicted_prob"] - r["market_price"]
+                edge_sign = "+" if edge > 0 else ""
+                edge_color = "green" if edge > 0.02 else "red" if edge < -0.02 else "yellow"
+
+                table.add_row(
+                    str(i),
+                    r["outcome"],
+                    f"{r['market_price']:.1%}",
+                    f"{r['predicted_prob']:.1%}",
+                    f"[{edge_color}]{edge_sign}{edge:.1%}[/]",
+                    (r.get("reasoning") or "")[:45],
+                )
+
             console.print(table)
+
+            # Show top pick
+            if active_results:
+                top = active_results[0]
+                console.print(Panel(
+                    f"[bold green]{top['outcome']}[/bold green] — "
+                    f"Predicted: [bold]{top['predicted_prob']:.1%}[/bold] | "
+                    f"Market: {top['market_price']:.1%}\n\n"
+                    f"{top.get('reasoning', '')}",
+                    title="Top Pick",
+                    border_style="green",
+                ))
+
+        else:
+            # --- Single YES/NO display ---
+            prob_color = "green" if prediction.probability > 0.5 else "red"
+            market_diff = prediction.probability - (event.tokens[0].price if event.tokens else 0.5)
+            diff_sign = "+" if market_diff > 0 else ""
+
+            console.print(Panel(
+                f"[bold {prob_color}]{prediction.probability:.1%}[/bold {prob_color}] probability of YES\n\n"
+                f"Confidence: [bold]{prediction.confidence:.1%}[/bold]\n"
+                f"Market price: {event.tokens[0].price:.1%}\n"
+                f"Difference: [{'green' if market_diff > 0 else 'red'}]{diff_sign}{market_diff:.1%}[/]",
+                title="Prediction",
+                border_style="green" if prediction.probability > 0.5 else "red",
+            ))
+
+            # Reasoning
+            console.print(Panel(
+                prediction.reasoning,
+                title="Reasoning",
+                border_style="yellow",
+            ))
+
+            # 7-day trajectory
+            if prediction.trajectory_7d:
+                table = Table(title="7-Day Price Trajectory")
+                for i, price in enumerate(prediction.trajectory_7d, 1):
+                    table.add_column(f"Day {i}", justify="center")
+                table.add_row(*[f"{p:.1%}" for p in prediction.trajectory_7d])
+                console.print(table)
 
         # News signals summary
         if news_signals:


### PR DESCRIPTION
- Detect multi-outcome events (NCAA, FIFA, Fed rate, oil prices) and predict all outcomes in one LLM call
- Display ranked predictions with market price, predicted probability, and edge
- Use groupItemTitle for cleaner outcome labels (e.g. "↑ $120", team names)
- Filter out placeholder/eliminated markets
- Auto-load .env via python-dotenv so no inline env vars needed