### PR TITLE
Release v0.1.0: Prepare for PyPI

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Orcetra Team
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,24 @@ build-backend = "hatchling.build"
 [project]
 name = "orcetra"
 version = "0.1.0"
-description = "AI-powered automated prediction engine. Give it data, it finds the best forecast."
+description = "AutoML prediction engine — give it data, it finds the best model. Wins 57% on 513 OpenML datasets vs AutoGluon and FLAML."
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"
 authors = [
-    {name = "Orcetra Team"},
+    {name = "Orcetra Team", email = "orcetra@gmail.com"},
+]
+keywords = ["automl", "machine-learning", "prediction", "automated-ml", "scikit-learn"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
     "click>=8.0",
@@ -23,10 +35,29 @@ dependencies = [
 [project.optional-dependencies]
 llm = ["groq", "openai"]
 xgboost = ["xgboost>=2.0"]
-all = ["orcetra[llm,xgboost]"]
+poly = ["httpx", "pydantic>=2.0"]
+all = ["orcetra[llm,xgboost,poly]"]
+
+[project.urls]
+Homepage = "https://orcetra.ai"
+Repository = "https://github.com/orcetra/orcetra"
+Dashboard = "https://orcetra.ai/dashboard.html"
 
 [project.scripts]
 orcetra = "orcetra.cli:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/orcetra"]
+
+[tool.hatch.build.targets.sdist]
+exclude = [
+    "results/",
+    "experiments/",
+    "video/",
+    "site/",
+    "dashboard/",
+    "catboost_*/",
+    "_deprecated_*/",
+    "*.log",
+    ".env",
+]


### PR DESCRIPTION
## Changes
- Add MIT LICENSE file
- Update `pyproject.toml`:
  - Proper classifiers, keywords, URLs (homepage, repo, dashboard)
  - Optional extras: `[llm]`, `[xgboost]`, `[poly]`, `[all]`
  - sdist exclude rules (results/, experiments/, video/, site/)
- Verified: `python3 -m build` produces clean wheel (34 files, no data leakage)

## After merge
```bash
python3 -m build
python3 -m twine upload dist/*
```

This will publish `orcetra 0.1.0` to PyPI → `pip install orcetra`