### PR TITLE
feat: add CatBoost to baseline model pool

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ dependencies = [
 [project.optional-dependencies]
 llm = ["groq", "openai"]
 xgboost = ["xgboost>=2.0"]
-all = ["orcetra[llm,xgboost]"]
+catboost = ["catboost>=1.2"]
+all = ["orcetra[llm,xgboost,catboost]"]
 
 [project.urls]
 Homepage = "https://orcetra.ai"

--- a/src/orcetra/models/baseline.py
+++ b/src/orcetra/models/baseline.py
@@ -23,6 +23,12 @@ try:
 except ImportError:
     _HAS_LGBM = False
 
+try:
+    from catboost import CatBoostRegressor, CatBoostClassifier
+    _HAS_CATBOOST = True
+except ImportError:
+    _HAS_CATBOOST = False
+
 
 def _safe_fit_predict(model, data_info, metric_fn, needs_scaling=False):
     """Fit model and return metric score. Handles scaling if needed."""
@@ -83,6 +89,13 @@ def lgbm_regression(data_info, metric_fn):
         LGBMRegressor(n_estimators=100, random_state=42, verbosity=-1, n_jobs=-1),
         data_info, metric_fn)
 
+def catboost_regression(data_info, metric_fn):
+    if not _HAS_CATBOOST:
+        raise ImportError("catboost not installed")
+    return _safe_fit_predict(
+        CatBoostRegressor(iterations=100, random_state=42, verbose=False),
+        data_info, metric_fn)
+
 
 # ── Classification baselines ──────────────────────────────────────────
 
@@ -124,4 +137,11 @@ def lgbm_classification(data_info, metric_fn):
         raise ImportError("lightgbm not installed")
     return _safe_fit_predict(
         LGBMClassifier(n_estimators=100, random_state=42, verbosity=-1, n_jobs=-1),
+        data_info, metric_fn)
+
+def catboost_classification(data_info, metric_fn):
+    if not _HAS_CATBOOST:
+        raise ImportError("catboost not installed")
+    return _safe_fit_predict(
+        CatBoostClassifier(iterations=100, random_state=42, verbose=False),
         data_info, metric_fn)

--- a/src/orcetra/models/registry.py
+++ b/src/orcetra/models/registry.py
@@ -4,12 +4,12 @@ from .baseline import (
     linear_regression, ridge_regression,
     random_forest_regression, extra_trees_regression,
     gradient_boosting_regression, hist_gradient_boosting_regression,
-    xgb_regression, lgbm_regression,
+    xgb_regression, lgbm_regression, catboost_regression,
     # Classification
     logistic_regression,
     random_forest_classification, extra_trees_classification,
     gradient_boosting_classification, hist_gradient_boosting_classification,
-    xgb_classification, lgbm_classification,
+    xgb_classification, lgbm_classification, catboost_classification,
 )
 
 def get_baselines(task_type: str) -> dict:
@@ -23,6 +23,7 @@ def get_baselines(task_type: str) -> dict:
             "HistGradientBoosting": hist_gradient_boosting_regression,
             "XGBoost": xgb_regression,
             "LightGBM": lgbm_regression,
+            "CatBoost": catboost_regression,
         }
     else:
         return {
@@ -33,4 +34,5 @@ def get_baselines(task_type: str) -> dict:
             "HistGradientBoosting": hist_gradient_boosting_classification,
             "XGBoost": xgb_classification,
             "LightGBM": lgbm_classification,
+            "CatBoost": catboost_classification,
         }


### PR DESCRIPTION
## Summary
Closes #10 (code changes only — benchmarking is a follow-up)

- Added `CatBoostRegressor` / `CatBoostClassifier` to `baseline.py` with optional import guard
- Registered `CatBoost` in both regression and classification pools in `registry.py`
- Added `catboost>=1.2` as optional dependency in `pyproject.toml`

## Still TODO (post-merge)
- [ ] Re-run 50 regression datasets to measure improvement
- [ ] Compare before/after win rate on regression tasks

## Test plan
- [x] Verified CatBoost regression baseline runs and returns valid MSE score
- [x] Verified CatBoost classification baseline runs and returns valid accuracy score
- [x] Verified all existing baselines still work with CatBoost added
- [x] Verified graceful `ImportError` when catboost is not installed