### PR TITLE
refactor: extract ensemble into standalone module

### DIFF
--- a/experiments/test_ensemble.py
+++ b/experiments/test_ensemble.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 """Smoke test for weighted ensemble."""
 import numpy as np
-from orcetra.core.loop import StrategyCache, _try_weighted_ensemble
+from orcetra.core.loop import StrategyCache
+from orcetra.models.ensemble import try_ensemble
 from orcetra.core.agent import Proposal
 from orcetra.metrics.base import get_metric
 from sklearn.ensemble import RandomForestRegressor, GradientBoostingRegressor, ExtraTreesRegressor
@@ -31,7 +32,7 @@ for model, name in models:
     print(f"  {name}: MSE={score:.4f}")
 
 console = Console()
-result = _try_weighted_ensemble(cache, data_info, metric_fn, 999, console)
+result = try_ensemble(cache, data_info, metric_fn, console)
 if result:
     print(f"  Ensemble: MSE={result[0]:.4f} -- {result[1]}")
 else:

--- a/src/orcetra/core/loop.py
+++ b/src/orcetra/core/loop.py
@@ -16,6 +16,7 @@ from rich.progress import Progress
 
 from ..data.loader import analyze_and_load
 from ..models.registry import get_baselines
+from ..models.ensemble import try_ensemble
 from ..metrics.base import get_metric
 
 console = Console()
@@ -29,101 +30,6 @@ def _evaluate_proposal(proposal, data_info, metric_fn):
         return (proposal, score, None)
     except Exception as e:
         return (proposal, None, str(e))
-
-
-# ── Post-search Weighted Ensemble ─────────────────────────────────────
-
-def _try_weighted_ensemble(cache, data_info, metric_fn, current_best, console):
-    """Build a weighted ensemble from the top-3 diverse models found during search.
-    
-    Returns (score, description) if ensemble was built, None otherwise.
-    """
-    import warnings
-    from sklearn.ensemble import VotingRegressor, VotingClassifier
-    
-    if len(cache.proposals) < 3:
-        return None
-    
-    task_type = data_info.get("task_type", "regression")
-    direction = metric_fn.direction
-    
-    # Only use proposals without preprocessors (ensemble re-fits on raw data)
-    eligible = [(p, s) for p, s in cache.proposals if p.preprocessor is None]
-    if len(eligible) < 3:
-        return None
-    
-    # Sort proposals by score (best first)
-    if direction == "minimize":
-        sorted_proposals = sorted(eligible, key=lambda x: x[1])
-    else:
-        sorted_proposals = sorted(eligible, key=lambda x: -x[1])
-    
-    # Pick top-3 diverse models (different model classes)
-    selected = []
-    seen_types = set()
-    for proposal, score in sorted_proposals:
-        # Use the model class name as diversity key
-        model_type = type(proposal.model).__name__
-        if model_type not in seen_types:
-            selected.append((proposal, score))
-            seen_types.add(model_type)
-        if len(selected) >= 3:
-            break
-    
-    if len(selected) < 2:
-        return None
-    
-    console.print(f"\n[bold]Step 4:[/bold] Trying weighted ensemble of top-{len(selected)} models...")
-    for p, s in selected:
-        console.print(f"  {p.description}: {s:.4f}")
-    
-    # Build ensemble with inverse-error weighting
-    # For minimize: weight = 1/score (lower score = higher weight)
-    # For maximize: weight = score (higher score = higher weight)
-    scores = [s for _, s in selected]
-    if direction == "minimize":
-        # Avoid division by zero
-        min_score = min(scores)
-        if min_score <= 0:
-            weights = [1.0] * len(selected)
-        else:
-            weights = [1.0 / s for s in scores]
-    else:
-        total = sum(scores)
-        if total <= 0:
-            weights = [1.0] * len(selected)
-        else:
-            weights = scores
-    
-    # Normalize weights
-    w_total = sum(weights)
-    weights = [w / w_total for w in weights]
-    
-    try:
-        estimators = [(f"m{i}", p.model) for i, (p, _) in enumerate(selected)]
-        
-        if task_type == "regression":
-            ensemble = VotingRegressor(estimators=estimators, weights=weights, n_jobs=-1)
-        else:
-            ensemble = VotingClassifier(estimators=estimators, weights=weights, voting="soft", n_jobs=-1)
-        
-        X_train = data_info["X_train"]
-        X_test = data_info["X_test"]
-        
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            ensemble.fit(X_train, data_info["y_train"])
-            preds = ensemble.predict(X_test)
-        
-        ens_score = metric_fn.compute(data_info["y_test"], preds)
-        names = "+".join(type(p.model).__name__ for p, _ in selected)
-        w_str = ",".join(f"{w:.2f}" for w in weights)
-        description = f"WeightedEnsemble({names}, w=[{w_str}])"
-        
-        return (ens_score, description)
-    except Exception as e:
-        console.print(f"  [red]Ensemble failed: {e}[/red]")
-        return None
 
 
 # ── Strategy Cache ────────────────────────────────────────────────────
@@ -362,7 +268,7 @@ def run_prediction(
     console.print(f"  Completed {iteration} strategies ({cache.tried_count} unique), {improvements} improvements")
     
     # Step 5: Post-search weighted ensemble — try top-3 diverse models
-    ensemble_score = _try_weighted_ensemble(cache, data_info, metric_fn, best_score, console)
+    ensemble_score = try_ensemble(cache, data_info, metric_fn, console)
     if ensemble_score is not None:
         ens_score, ens_desc = ensemble_score
         is_better = (

--- a/src/orcetra/models/ensemble.py
+++ b/src/orcetra/models/ensemble.py
@@ -1,0 +1,169 @@
+"""Weighted ensemble of top-K diverse models.
+
+Standalone module for building ensembles from search results.
+Supports both weighted and simple (equal-weight) strategies,
+returning whichever scores better.
+
+Importable for both the CLI loop and benchmark scripts.
+"""
+import time
+import warnings
+import numpy as np
+from sklearn.ensemble import VotingRegressor, VotingClassifier
+
+
+def compute_weights(scores: list[float], direction: str) -> list[float]:
+    """Compute ensemble weights from scores (softmax over normalized scores).
+
+    Better-scoring models get higher weight. Uses softmax for numerical stability.
+
+    Args:
+        scores: List of metric scores for each model.
+        direction: "minimize" or "maximize".
+
+    Returns:
+        List of normalized weights summing to 1.0.
+    """
+    arr = np.array(scores, dtype=float)
+    if direction == "minimize":
+        arr = -arr
+    arr = arr - arr.max()
+    weights = np.exp(arr)
+    weights = weights / weights.sum()
+    return weights.tolist()
+
+
+def select_diverse_models(proposals_with_scores, direction: str, top_k: int = 3):
+    """Select top-K diverse models from a list of (proposal, score) pairs.
+
+    Diversity is enforced by picking at most one model per class name.
+
+    Args:
+        proposals_with_scores: List of (proposal, score) tuples.
+            Each proposal must have .model and .preprocessor attributes.
+        direction: "minimize" or "maximize".
+        top_k: Maximum number of models to select.
+
+    Returns:
+        List of (proposal, score) tuples, or empty list if fewer than 2 eligible.
+    """
+    # Only use proposals without preprocessors (ensemble re-fits on raw data)
+    eligible = [(p, s) for p, s in proposals_with_scores if p.preprocessor is None]
+    if len(eligible) < 2:
+        return []
+
+    if direction == "minimize":
+        sorted_proposals = sorted(eligible, key=lambda x: x[1])
+    else:
+        sorted_proposals = sorted(eligible, key=lambda x: -x[1])
+
+    selected = []
+    seen_types = set()
+    for proposal, score in sorted_proposals:
+        model_type = type(proposal.model).__name__
+        if model_type not in seen_types:
+            selected.append((proposal, score))
+            seen_types.add(model_type)
+        if len(selected) >= top_k:
+            break
+
+    if len(selected) < 2:
+        return []
+    return selected
+
+
+def build_ensemble(selected, data_info, metric_fn, time_budget: float = 30.0):
+    """Build a weighted ensemble from selected (proposal, score) pairs.
+
+    Tries both simple (equal-weight) and inverse-error-weighted strategies,
+    returning whichever scores better.
+
+    Args:
+        selected: List of (proposal, score) tuples (from select_diverse_models).
+        data_info: Dict with X_train, X_test, y_train, y_test, task_type.
+        metric_fn: Metric object with .compute() and .direction.
+        time_budget: Maximum seconds for the ensemble process (default 30s).
+
+    Returns:
+        (ensemble_score, description_string) or None if ensemble failed.
+    """
+    t_start = time.time()
+    task_type = data_info.get("task_type", "regression")
+    direction = metric_fn.direction
+    scores = [s for _, s in selected]
+
+    # Build both simple and weighted ensembles, return the better one
+    simple_weights = [1.0 / len(selected)] * len(selected)
+    weighted = compute_weights(scores, direction)
+
+    results = []
+    for label, weights in [("SimpleEnsemble", simple_weights), ("WeightedEnsemble", weighted)]:
+        if time.time() - t_start > time_budget:
+            break
+
+        try:
+            estimators = [(f"m{i}", p.model) for i, (p, _) in enumerate(selected)]
+
+            if task_type == "regression":
+                ensemble = VotingRegressor(estimators=estimators, weights=weights, n_jobs=1)
+            else:
+                ensemble = VotingClassifier(estimators=estimators, weights=weights, voting="soft", n_jobs=1)
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                ensemble.fit(data_info["X_train"], data_info["y_train"])
+                preds = ensemble.predict(data_info["X_test"])
+
+            ens_score = metric_fn.compute(data_info["y_test"], preds)
+            names = "+".join(type(p.model).__name__ for p, _ in selected)
+            w_str = ",".join(f"{w:.2f}" for w in weights)
+            desc = f"{label}({names}, w=[{w_str}])"
+            results.append((ens_score, desc))
+        except Exception:
+            continue
+
+    if not results:
+        return None
+
+    # Pick the better result
+    if len(results) == 1:
+        return results[0]
+
+    score_a, desc_a = results[0]
+    score_b, desc_b = results[1]
+    if direction == "minimize":
+        return results[0] if score_a <= score_b else results[1]
+    else:
+        return results[0] if score_a >= score_b else results[1]
+
+
+def try_ensemble(cache, data_info, metric_fn, console, time_budget: float = 30.0):
+    """High-level entry point: select diverse models from cache and build ensemble.
+
+    This is the main function called from the prediction loop.
+
+    Args:
+        cache: StrategyCache with .proposals list of (proposal, score).
+        data_info: Dict with X_train, X_test, y_train, y_test, task_type.
+        metric_fn: Metric object with .compute() and .direction.
+        console: Rich console for output.
+        time_budget: Maximum seconds for the ensemble process.
+
+    Returns:
+        (ensemble_score, description_string) or None.
+    """
+    if len(cache.proposals) < 3:
+        return None
+
+    selected = select_diverse_models(cache.proposals, metric_fn.direction, top_k=3)
+    if not selected:
+        return None
+
+    console.print(f"\n[bold]Step 4:[/bold] Trying ensemble of top-{len(selected)} diverse models...")
+    for p, s in selected:
+        console.print(f"  {p.description}: {s:.4f}")
+
+    result = build_ensemble(selected, data_info, metric_fn, time_budget=time_budget)
+    if result is None:
+        console.print("  [red]Ensemble failed[/red]")
+    return result

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -1,0 +1,180 @@
+"""Unit tests for orcetra.models.ensemble module."""
+import numpy as np
+import pytest
+from dataclasses import dataclass
+from sklearn.ensemble import (
+    RandomForestRegressor, GradientBoostingRegressor, ExtraTreesRegressor,
+    RandomForestClassifier, GradientBoostingClassifier, ExtraTreesClassifier,
+)
+from sklearn.datasets import make_regression, make_classification
+from sklearn.model_selection import train_test_split
+
+from orcetra.models.ensemble import compute_weights, select_diverse_models, build_ensemble, try_ensemble
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+@dataclass
+class FakeProposal:
+    description: str
+    model: object
+    preprocessor: object = None
+
+
+class FakeMetric:
+    def __init__(self, direction):
+        self.direction = direction
+        self.name = "fake"
+
+    def compute(self, y_true, y_pred):
+        from sklearn.metrics import mean_squared_error, accuracy_score
+        if self.direction == "minimize":
+            return mean_squared_error(y_true, y_pred)
+        return accuracy_score(y_true, y_pred)
+
+
+class FakeCache:
+    def __init__(self, proposals):
+        self.proposals = proposals
+
+
+def _make_regression_data():
+    X, y = make_regression(n_samples=200, n_features=5, random_state=42)
+    Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.3, random_state=42)
+    return {"X_train": Xtr, "X_test": Xte, "y_train": ytr, "y_test": yte, "task_type": "regression"}
+
+
+def _make_classification_data():
+    X, y = make_classification(n_samples=200, n_features=5, random_state=42)
+    Xtr, Xte, ytr, yte = train_test_split(X, y, test_size=0.3, random_state=42)
+    return {"X_train": Xtr, "X_test": Xte, "y_train": ytr, "y_test": yte, "task_type": "classification"}
+
+
+# ── Tests: compute_weights ───────────────────────────────────────────
+
+class TestComputeWeights:
+    def test_maximize_higher_score_gets_higher_weight(self):
+        weights = compute_weights([0.9, 0.8, 0.7], "maximize")
+        assert weights[0] > weights[1] > weights[2]
+
+    def test_minimize_lower_score_gets_higher_weight(self):
+        weights = compute_weights([1.0, 2.0, 3.0], "minimize")
+        assert weights[0] > weights[1] > weights[2]
+
+    def test_weights_sum_to_one(self):
+        weights = compute_weights([0.5, 0.8, 0.6], "maximize")
+        assert abs(sum(weights) - 1.0) < 1e-6
+
+    def test_equal_scores_equal_weights(self):
+        weights = compute_weights([0.5, 0.5, 0.5], "maximize")
+        assert abs(weights[0] - weights[1]) < 1e-6
+        assert abs(weights[1] - weights[2]) < 1e-6
+
+
+# ── Tests: select_diverse_models ─────────────────────────────────────
+
+class TestSelectDiverseModels:
+    def test_selects_diverse_model_types(self):
+        proposals = [
+            (FakeProposal("rf1", RandomForestRegressor()), 1.0),
+            (FakeProposal("rf2", RandomForestRegressor()), 1.1),
+            (FakeProposal("gbm", GradientBoostingRegressor()), 1.2),
+            (FakeProposal("et", ExtraTreesRegressor()), 1.5),
+        ]
+        selected = select_diverse_models(proposals, "minimize", top_k=3)
+        types = [type(p.model).__name__ for p, _ in selected]
+        assert len(types) == len(set(types)), "Should pick distinct model types"
+
+    def test_skips_proposals_with_preprocessor(self):
+        proposals = [
+            (FakeProposal("rf", RandomForestRegressor(), preprocessor="scaler"), 1.0),
+            (FakeProposal("gbm", GradientBoostingRegressor()), 1.2),
+            (FakeProposal("et", ExtraTreesRegressor()), 1.5),
+        ]
+        selected = select_diverse_models(proposals, "minimize", top_k=3)
+        assert len(selected) == 2
+
+    def test_returns_empty_if_fewer_than_2_eligible(self):
+        proposals = [
+            (FakeProposal("rf", RandomForestRegressor()), 1.0),
+        ]
+        assert select_diverse_models(proposals, "minimize") == []
+
+    def test_respects_top_k(self):
+        proposals = [
+            (FakeProposal("rf", RandomForestRegressor()), 1.0),
+            (FakeProposal("gbm", GradientBoostingRegressor()), 1.2),
+            (FakeProposal("et", ExtraTreesRegressor()), 1.5),
+        ]
+        selected = select_diverse_models(proposals, "minimize", top_k=2)
+        assert len(selected) == 2
+
+
+# ── Tests: build_ensemble ────────────────────────────────────────────
+
+class TestBuildEnsemble:
+    def test_regression_returns_score_and_description(self):
+        data = _make_regression_data()
+        selected = [
+            (FakeProposal("rf", RandomForestRegressor(n_estimators=10, random_state=42)), 1.0),
+            (FakeProposal("et", ExtraTreesRegressor(n_estimators=10, random_state=42)), 1.2),
+        ]
+        result = build_ensemble(selected, data, FakeMetric("minimize"))
+        assert result is not None
+        score, desc = result
+        assert isinstance(score, float)
+        assert "Ensemble" in desc
+
+    def test_classification_returns_score_and_description(self):
+        data = _make_classification_data()
+        selected = [
+            (FakeProposal("rf", RandomForestClassifier(n_estimators=10, random_state=42)), 0.8),
+            (FakeProposal("et", ExtraTreesClassifier(n_estimators=10, random_state=42)), 0.75),
+        ]
+        result = build_ensemble(selected, data, FakeMetric("maximize"))
+        assert result is not None
+        score, desc = result
+        assert isinstance(score, float)
+        assert 0.0 <= score <= 1.0
+
+    def test_time_budget_zero_returns_none(self):
+        data = _make_regression_data()
+        selected = [
+            (FakeProposal("rf", RandomForestRegressor(n_estimators=10, random_state=42)), 1.0),
+            (FakeProposal("et", ExtraTreesRegressor(n_estimators=10, random_state=42)), 1.2),
+        ]
+        result = build_ensemble(selected, data, FakeMetric("minimize"), time_budget=0)
+        assert result is None
+
+
+# ── Tests: try_ensemble (integration) ────────────────────────────────
+
+class TestTryEnsemble:
+    def test_returns_none_if_fewer_than_3_proposals(self):
+        cache = FakeCache([])
+        result = try_ensemble(cache, {}, FakeMetric("minimize"), None)
+        assert result is None
+
+    def test_full_pipeline_regression(self):
+        from rich.console import Console
+        data = _make_regression_data()
+        metric = FakeMetric("minimize")
+
+        models = [
+            RandomForestRegressor(n_estimators=10, random_state=42),
+            GradientBoostingRegressor(n_estimators=10, random_state=42),
+            ExtraTreesRegressor(n_estimators=10, random_state=42),
+        ]
+        proposals = []
+        for m in models:
+            p = FakeProposal(type(m).__name__, m)
+            m.fit(data["X_train"], data["y_train"])
+            score = metric.compute(data["y_test"], m.predict(data["X_test"]))
+            proposals.append((p, score))
+
+        cache = FakeCache(proposals)
+        console = Console(quiet=True)
+        result = try_ensemble(cache, data, metric, console)
+        assert result is not None
+        score, desc = result
+        assert isinstance(score, float)


### PR DESCRIPTION
## Summary
Closes #29

Extracts the inline `_try_weighted_ensemble` from `loop.py` into a dedicated `src/orcetra/models/ensemble.py` module with a clean public API:

- `compute_weights()` — softmax-based inverse-error weighting
- `select_diverse_models()` — top-K selection enforcing model type diversity
- `build_ensemble()` — tries both simple and weighted strategies, returns the better one
- `try_ensemble()` — high-level entry point used by the prediction loop

Also includes time budget enforcement (default 30s) and is importable for both CLI and benchmark scripts.

## Changes
- `src/orcetra/models/ensemble.py` — new standalone ensemble module
- `src/orcetra/core/loop.py` — removed inline ensemble, imports from new module
- `experiments/test_ensemble.py` — updated import path
- `tests/test_ensemble.py` — 13 unit tests covering all public functions

## Test plan
- [x] 13 unit tests pass (weights, diversity, build, integration)
- [x] Existing smoke test (`experiments/test_ensemble.py`) works with new imports
- [x] Ensemble correctly picks better of simple vs weighted strategy